### PR TITLE
Tello: Joy node and Tello Driver modification (teleoperation purpose)

### DIFF
--- a/tello_driver/CMakeLists.txt
+++ b/tello_driver/CMakeLists.txt
@@ -31,7 +31,8 @@ find_package(ros2_shared REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tello_msgs REQUIRED)
-
+find_package(lifecycle_msgs REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 # Package includes not needed for CMake >= 2.8.11
 include_directories(
   include
@@ -66,7 +67,9 @@ set(DRIVER_NODE_DEPS
   ros2_shared
   sensor_msgs
   std_msgs
-  tello_msgs)
+  tello_msgs
+  rclcpp_lifecycle
+  std_msgs)
 
 set(DRIVER_NODE_LIBS
   avcodec
@@ -119,7 +122,8 @@ set(JOY_NODE_DEPS
   rclcpp
   rclcpp_components
   sensor_msgs
-  tello_msgs)
+  tello_msgs
+  rclcpp_lifecycle)
 
 add_library(tello_joy_node SHARED
   ${JOY_NODE_SOURCES})

--- a/tello_driver/include/tello_driver_node.hpp
+++ b/tello_driver/include/tello_driver_node.hpp
@@ -7,8 +7,9 @@
 #include "tello_msgs/msg/flight_data.hpp"
 #include "tello_msgs/msg/tello_response.hpp"
 #include "tello_msgs/srv/tello_action.hpp"
-
+#include <std_msgs/msg/string.hpp>
 #include "h264decoder.hpp"
+#include "string"
 
 using asio::ip::udp;
 
@@ -45,13 +46,35 @@ namespace tello_driver
 
     ~TelloDriverNode();
 
+    enum class FlightState
+    {
+      landed,
+      taking_off,
+      flying,
+      landing,
+      low_battery,
+    };
+
+    std::map<FlightState, const char *> state_strs_{
+      {FlightState::landed,       "landed"},
+      {FlightState::taking_off,   "taking_off"},
+      {FlightState::flying,       "flying"},
+      {FlightState::landing,      "landing"},
+      {FlightState::low_battery, "low_battery"},
+    };
+
+    FlightState flight_state_ = FlightState::landed;
     // ROS publishers
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub_;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
     rclcpp::Publisher<tello_msgs::msg::FlightData>::SharedPtr flight_data_pub_;
     rclcpp::Publisher<tello_msgs::msg::TelloResponse>::SharedPtr tello_response_pub_;
 
+    
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr tello_state_pub_;
   private:
+
+    void update_tello_state(FlightState next);
 
     void timer_callback();
 
@@ -75,6 +98,7 @@ namespace tello_driver
 
     // ROS timer
     rclcpp::TimerBase::SharedPtr spin_timer_;
+
   };
 
   //=====================================================================================

--- a/tello_driver/include/tello_joy_node.hpp
+++ b/tello_driver/include/tello_joy_node.hpp
@@ -2,6 +2,8 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "sensor_msgs/msg/joy.hpp"
 #include "tello_msgs/srv/tello_action.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 
 namespace tello_joy
 {
@@ -18,20 +20,35 @@ namespace tello_joy
   constexpr int JOY_BUTTON_VIEW = 6;        // View button
   constexpr int JOY_BUTTON_MENU = 7;        // Menu button
 
-  class TelloJoyNode : public rclcpp::Node
+  class TelloJoyNode : public rclcpp_lifecycle::LifecycleNode
   {
   public:
 
     explicit TelloJoyNode(const rclcpp::NodeOptions &options);
 
     ~TelloJoyNode();
+    // Add lifecycle callbacks
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    on_configure(const rclcpp_lifecycle::State &previous_state) override;
+    
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    on_activate(const rclcpp_lifecycle::State &previous_state) override;
+    
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    on_deactivate(const rclcpp_lifecycle::State &previous_state) override;
+
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    on_cleanup(const rclcpp_lifecycle::State &previous_state) override;
+
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    on_shutdown(const rclcpp_lifecycle::State &previous_state) override;
 
   private:
 
     void joy_callback(const sensor_msgs::msg::Joy::SharedPtr joy_msg);
 
     rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
-    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub_;
+    rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub_;
     rclcpp::Client<tello_msgs::srv::TelloAction>::SharedPtr tello_client_;
 
     // XBox One assignments

--- a/tello_driver/package.xml
+++ b/tello_driver/package.xml
@@ -26,7 +26,7 @@
     <depend>sensor_msgs</depend>
     <depend>std_msgs</depend>
     <depend>tello_msgs</depend>
-
+    <depend>rclcpp_lifecycle</depend>
     <export>
         <build_type>ament_cmake</build_type>
     </export>

--- a/tello_driver/src/tello_joy_main.cpp
+++ b/tello_driver/src/tello_joy_main.cpp
@@ -20,8 +20,7 @@ int main(int argc, char **argv)
 
   // Create and add joy node
   auto joy_node = std::make_shared<tello_joy::TelloJoyNode>(options);
-  executor.add_node(joy_node);
-
+  executor.add_node(joy_node->get_node_base_interface());
   // Spin until rclcpp::ok() returns false
   executor.spin();
 

--- a/tello_driver/src/tello_joy_node.cpp
+++ b/tello_driver/src/tello_joy_node.cpp
@@ -8,32 +8,101 @@
 namespace tello_joy
 {
 
+  
   TelloJoyNode::TelloJoyNode(const rclcpp::NodeOptions &options) :
-    Node("tello_joy", options)
+    rclcpp_lifecycle::LifecycleNode("tello_joy", options)
   {
-    using std::placeholders::_1;
 
-    joy_sub_ = create_subscription<sensor_msgs::msg::Joy>("joy", 1, std::bind(&TelloJoyNode::joy_callback, this, _1));
-    cmd_vel_pub_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
-    tello_client_ = create_client<tello_msgs::srv::TelloAction>("tello_action");
-
-    (void) joy_sub_;
   }
-
+  
   TelloJoyNode::~TelloJoyNode()
   {}
 
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  TelloJoyNode::on_configure(const rclcpp_lifecycle::State & previous_state)
+  {
+    RCLCPP_INFO(get_logger(), "Configuring TelloJoy node...");
+    
+    using std::placeholders::_1;
+    joy_sub_ = create_subscription<sensor_msgs::msg::Joy>(
+      "joy", 1, 
+      std::bind(&TelloJoyNode::joy_callback, this, _1));
+      
+    cmd_vel_pub_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
 
+    tello_client_ = create_client<tello_msgs::srv::TelloAction>("tello_action");
+
+    (void) joy_sub_;
+
+    RCLCPP_INFO(get_logger(), "Node configured");
+    return CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  TelloJoyNode::on_activate(const rclcpp_lifecycle::State & previous_state)
+  {
+    RCLCPP_INFO(get_logger(), "Activating command controller in TelloJoy node...");
+    
+    // Activate the publisher
+
+    cmd_vel_pub_->on_activate();
+    
+    RCLCPP_INFO(get_logger(), "Controller activated");
+    return CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  TelloJoyNode::on_deactivate(const rclcpp_lifecycle::State & previous_state)
+  {
+    RCLCPP_INFO(get_logger(), "Deactivating command controller in TelloJoy node...");
+    
+    // Deactivate the publisher
+    cmd_vel_pub_->on_deactivate();
+    
+    RCLCPP_INFO(get_logger(), "controller deactivated");
+    return CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  TelloJoyNode::on_cleanup(const rclcpp_lifecycle::State & previous_state)
+  {
+    RCLCPP_INFO(get_logger(), "Cleaning up TelloJoy node...");
+    
+    // Reset all member variables
+    joy_sub_.reset();
+    cmd_vel_pub_.reset();
+    tello_client_.reset();
+    
+    RCLCPP_INFO(get_logger(), "Node cleaned up");
+    return CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  TelloJoyNode::on_shutdown(const rclcpp_lifecycle::State & previous_state)
+  {
+    RCLCPP_INFO(get_logger(), "Shutting down TelloJoy node...");
+    
+    // Reset all member variables
+    joy_sub_.reset();
+    cmd_vel_pub_.reset();
+    tello_client_.reset();
+    
+    RCLCPP_INFO(get_logger(), "Node shut down");
+    return CallbackReturn::SUCCESS;
+  }
+  
   void TelloJoyNode::joy_callback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
   {
     if (joy_msg->buttons[joy_button_takeoff_]) {
       auto request = std::make_shared<tello_msgs::srv::TelloAction::Request>();
       request->cmd = "takeoff";
       tello_client_->async_send_request(request);
+      RCLCPP_INFO(get_logger(), "request takeoff");
     } else if (joy_msg->buttons[joy_button_land_]) {
       auto request = std::make_shared<tello_msgs::srv::TelloAction::Request>();
       request->cmd = "land";
       tello_client_->async_send_request(request);
+      RCLCPP_INFO(get_logger(), "request landing");
     } else {
       geometry_msgs::msg::Twist twist_msg;
       twist_msg.linear.x = joy_msg->axes[joy_axis_throttle_];
@@ -41,6 +110,7 @@ namespace tello_joy
       twist_msg.linear.z = joy_msg->axes[joy_axis_vertical_];
       twist_msg.angular.z = joy_msg->axes[joy_axis_yaw_];
       cmd_vel_pub_->publish(twist_msg);
+      //RCLCPP_INFO(get_logger(), "sending rc command");
     }
   }
 


### PR DESCRIPTION
Problem
=======
1. Joy node (teleoperation) is not a lifecycle node originally, so we cannot control when to allow action request and teleoperation control
2. Tello package doesnt have state tracker, for future implementation states will be crucial for the Controller Node

Solution
========
1. Modify Joy Node into a lifecycle node.
2. Add a class called 'FlighState' to keep track of drone state based on action and response
3. Publish flight state to '/tello_state' topic , so tello controller can use it as reference of drone current state

Note
====
1. These nodes are called within our tello controller launch in sensors package
2. i need help regarding integrating the tello_gazebo package as it needs some dependencies in the container