### PR TITLE
Tello State Machine Update

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,30 @@
+# Title: Summary, imperative, start upper case, don't end with a period
+# Include Task Epic in the summary in the following format
+# <EPIC>:<SUBJECT>
+# No more than 50 chars. #### 50 chars is here:  #
+
+# Remember blank line between title and body.
+
+# Body: Explain *what* and *why* (not *how*).
+# Wrap at 72 chars. ################################## which is here:  #
+
+Problem
+=======
+# Describe the problem solved here briefly. Do not exceed more than 3 lines
+# Body of Problem starts here
+
+# Body of Problem ends here. Ensure blank line after every section.
+
+Solution
+========
+# List of changes made to solve aforementioned problem
+# Body of Solution starts here
+
+# Body of Solution ends here. Ensure blank line after every section.
+
+Note
+====
+# Additional notes, special instructions, testing steps, rake, etc
+# Body of Note starts here
+
+# Body of Note ends here

--- a/tello_driver/include/tello_driver_node.hpp
+++ b/tello_driver/include/tello_driver_node.hpp
@@ -48,6 +48,7 @@ namespace tello_driver
 
     enum class FlightState
     {
+	  Idle,
       Landed,
       TakingOff,
       Flying,
@@ -56,6 +57,7 @@ namespace tello_driver
     };
 
     std::map<FlightState, const char *> state_strs_{
+      {FlightState::Idle,       "idle"},
       {FlightState::Landed,       "landed"},
       {FlightState::TakingOff,   "taking_off"},
       {FlightState::Flying,       "flying"},
@@ -63,7 +65,8 @@ namespace tello_driver
       {FlightState::LowBattery, "low_battery"},
     };
 
-    FlightState flight_state_ = FlightState::Landed;
+    FlightState flight_state_ = FlightState::Idle;
+	FlightState mpPrevFlightState = FlightState::Idle;
     // ROS publishers
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub_;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
@@ -84,6 +87,7 @@ namespace tello_driver
       std::shared_ptr<tello_msgs::srv::TelloAction::Response> response);
 
     void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
+	void tello_response_callback(const tello_msgs::msg::TelloResponse::SharedPtr msg);
 
     // Sockets
     std::unique_ptr<CommandSocket> command_socket_;
@@ -95,9 +99,13 @@ namespace tello_driver
 
     // ROS subscriptions
     rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
+	rclcpp::Subscription<tello_msgs::msg::TelloResponse>::SharedPtr tello_response_sub_;
 
     // ROS timer
     rclcpp::TimerBase::SharedPtr spin_timer_;
+
+	std::string last_requested_command_;
+	std::mutex mtx_;
 
   };
 

--- a/tello_driver/include/tello_joy_node.hpp
+++ b/tello_driver/include/tello_joy_node.hpp
@@ -58,6 +58,8 @@ namespace tello_joy
     const int joy_axis_yaw_ = JOY_AXIS_LEFT_LR;
     const int joy_button_takeoff_ = JOY_BUTTON_MENU;
     const int joy_button_land_ = JOY_BUTTON_VIEW;
+
+	std::string mpDroneName;
   };
 
 } // namespace tello_joy

--- a/tello_driver/src/tello_joy_main.cpp
+++ b/tello_driver/src/tello_joy_main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
   // Create and add joy node
   auto joy_node = std::make_shared<tello_joy::TelloJoyNode>(options);
   executor.add_node(joy_node->get_node_base_interface());
-  joy_node->configure();
+  // joy_node->configure();
   // Spin until rclcpp::ok() returns false
   executor.spin();
 

--- a/tello_driver/src/tello_joy_node.cpp
+++ b/tello_driver/src/tello_joy_node.cpp
@@ -12,7 +12,10 @@ namespace tello_joy
   TelloJoyNode::TelloJoyNode(const rclcpp::NodeOptions &options) :
     rclcpp_lifecycle::LifecycleNode("tello_joy", options)
   {
-
+	  rcl_interfaces::msg::ParameterDescriptor droneNameDesc;
+	  droneNameDesc.description = "Path to output file for received video";
+	  droneNameDesc.type = 4;
+	  this->declare_parameter<std::string>("drone_name", "drone1", droneNameDesc);
   }
   
   TelloJoyNode::~TelloJoyNode()
@@ -23,12 +26,16 @@ namespace tello_joy
   {
     RCLCPP_INFO(get_logger(), "Configuring TelloJoy node...");
     
+	mpDroneName = this->get_parameter("drone_name").as_string();
+
     using std::placeholders::_1;
     joy_sub_ = create_subscription<sensor_msgs::msg::Joy>(
       "joy", 1, 
       std::bind(&TelloJoyNode::joy_callback, this, _1));
       
-    cmd_vel_pub_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
+
+	std::string cmdVelTopic = "/" + mpDroneName + "/cmd_vel";
+    cmd_vel_pub_ = create_publisher<geometry_msgs::msg::Twist>(cmdVelTopic, 1);
 
     tello_client_ = create_client<tello_msgs::srv::TelloAction>("tello_action");
 

--- a/tello_msgs/CMakeLists.txt
+++ b/tello_msgs/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 project(tello_msgs)
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 # Default to C++14
 if (NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -28,6 +32,8 @@ rosidl_generate_interfaces(
   "msg/TelloResponse.msg"
   "srv/TelloAction.srv"
   DEPENDENCIES std_msgs
+  LIBRARY_NAME ${PROJECT_NAME}
 )
 
+ament_export_dependencies(rosidl_default_runtime)
 ament_package()


### PR DESCRIPTION
# Pull Request Changelog                                                                                                                                                                                                                                                 

## Problems
1. TakeOff Signal directly changes state to flying. An intermediate Taking Off state required
2. Landing Signal directly changes statwe to landed. An intermediate Landing state required
3. No State to signify no activity just after power on
4. Need to specify drone name to `TelloJoyNode`

## Solutions
1. Added Idle Flight State in `class TelloDriverNode` `tello_driver/include/tello_driver_node.hpp`
2. Implemented `TelloDriverNode::tello_response_callback()` as a callback to `tell_response_sub_`. The subccriber subscribes to the topic `~/tello_response` and responds to tello action reponse depending on what the last requested command is.
3. Added parameter declaration and fetching in `class TelloJoyNode` to store `mpDroneName` to subscribe to correct tello drone
4. Updated TelloDriverNode with additional state in state transition schema

## Notes
